### PR TITLE
Added discharge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fill in the three input numbers for charge, and set your usable battery capacity
 
 Requires forcast.solar integration: https://www.home-assistant.io/integrations/forecast_solar/
 
-I plan to add support for setting battery discharge times and current to accomodate people who are on the new Octopus Flux tariff. Everything is written for this and being tested now. I should be able to upload in the next week or so.
+Added support for Discharging - can be used for Flux to discharge at peak times, for Octopus saving sessions. I also use this to bump excess enegry into my EV overnight.
 
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/eco7-automations.yaml
+++ b/eco7-automations.yaml
@@ -95,7 +95,7 @@ automations:
   - id: '1678731184171'
     alias: Set Flux Discharge Current
     description: >-
-       Sets the Flix Discharge Current at the start of the Flux period every 30
+       Sets the Flux Discharge Current at the start of the Flux period every 30
        minutes during the Flux Period provided the Flux input_boolean is on
      trigger:
        - platform: time_pattern

--- a/eco7-automations.yaml
+++ b/eco7-automations.yaml
@@ -95,7 +95,7 @@ automations:
   - id: '1678731184171'
     alias: Set Flux Discharge Current
     description: >-
-       Sets the Flux Discharge Current at the start of the Flux period every 30
+       Sets the Flux Discharge Current at the start of the Flux period every 5
        minutes during the Flux Period provided the Flux input_boolean is on
      trigger:
        - platform: time_pattern
@@ -119,7 +119,7 @@ automations:
   - id: '1678731184172'
      alias: " Solis Set Flux Discharge Times "
      description: >-
-       Changes the Fixed Charging times on the inverter whenever the Flux
+       Changes the Fixed Discharging times on the inverter whenever the Flux
        input_datetime entities change
       trigger:
        - platform: time_pattern

--- a/eco7-automations.yaml
+++ b/eco7-automations.yaml
@@ -91,3 +91,53 @@ automations:
       data:
         value: '{{ states(''sensor.target_battery_charge_weekday'') | int(0) }}'
     mode: single
+
+  - id: '1678731184171'
+    alias: Set Flux Discharge Current
+    description: >-
+       Sets the Flix Discharge Current at the start of the Flux period every 30
+       minutes during the Flux Period provided the Flux input_boolean is on
+     trigger:
+       - platform: time_pattern
+         minutes: "0"
+       - platform: time_pattern
+         minutes: /5
+       - platform: time
+         at: input_datetime.flux_discharge_start
+     condition:
+      - condition: template
+        value_template: >-
+          {{(now() >= today_at(states('input_datetime.flux_discharge_start'))) and
+          (now() < today_at(states('input_datetime.flux_discharge_end'))) and
+          states('input_boolean.solis_flux_discharging') == 'on'}}
+    action:
+      - service: script.solis_set_discharge_current
+        data:
+          discharge_current: "{{states('sensor.solis_flux_discharge_current_template') | float}}"
+    mode: restart
+
+  - id: '1678731184172'
+     alias: " Solis Set Flux Discharge Times "
+     description: >-
+       Changes the Fixed Charging times on the inverter whenever the Flux
+       input_datetime entities change
+      trigger:
+       - platform: time_pattern
+         minutes: /5
+       - platform: state
+         entity_id:
+           - input_boolean.solis_flux_discharging
+     condition:
+       - condition: template
+         value_template: >-
+           {{strptime(states('input_datetime.flux_discharge_end'),'%H:%M:%S').time()
+           >strptime(states('input_datetime.flux_discharge_start'),'%H:%M:%S').time()}}
+     action:
+       - delay:
+           hours: 0
+           minutes: 0
+           seconds: 10
+           milliseconds: 0
+       - service: script.solis_set_flux_times
+         data: {}
+     mode: single

--- a/inputs.yaml
+++ b/inputs.yaml
@@ -45,6 +45,18 @@ input_datetime:
     has_time: true
     icon: mdi:clock-digital
 
+  flux_discharge_start:
+    name: Discharge Start
+    has_date: false
+    has_time: true
+    icon: mdi:clock-digital
+
+  flux_discharge_end:
+    name: Discharge End
+    has_date: false
+    has_time: true
+    icon: mdi:clock-digital
+
 input_number:
   eco7_target_soc:
     name: Economy 7 Target SOC

--- a/inputs.yaml
+++ b/inputs.yaml
@@ -7,6 +7,10 @@ input_boolean:
     name: Solis Eco7 Charging
     icon: mdi:flash
 
+  solis_flux_discharging:
+    name: Octopus Flux Discharging
+    icon: mdi:battery-charging-high
+
   saver_session:
     name: Saver Session
     icon: mdi:transmission-tower

--- a/inputs.yaml
+++ b/inputs.yaml
@@ -56,6 +56,16 @@ input_number:
     step: 1
     icon: mdi:battery
 
+ flux_target_soc:
+    name: Flux Discharge Target SOC
+    initial: 60
+    mode: box
+    unit_of_measurement: "%"
+    min: 0
+    max: 100
+    step: 1
+    icon: mdi:battery  
+
   solis_battery_capacity:
     name: Solis Battery Capacity
     initial: 5

--- a/solis-template.yaml
+++ b/solis-template.yaml
@@ -101,6 +101,18 @@ sensor:
           {{max((((today_at(states('input_datetime.economy_7_end')) - 
             max(now(), today_at(states('input_datetime.economy_7_start')))).total_seconds() / 36) | int) / 100,0)}}
       {%- endif %}
+ 
+  -  name: "Solis Flux Discharge Hours Remaining"
+      unique_id: "Solis Flux Discharge Time Remaining"
+      state_class: measurement
+      state: >-
+        {% if today_at(states('input_datetime.flux_discharge_end')) < now() -%}
+            {{(((today_at(states('input_datetime.flux_discharge_end')) - 
+              today_at(states('input_datetime.flux_discharge_start')))).total_seconds() / 36) | int / 100}}
+        {%- else -%}
+            {{max((((today_at(states('input_datetime.flux_discharge_end')) - 
+              max(now(), today_at(states('input_datetime.flux_discharge_start')))).total_seconds() / 36) | int) / 100,0)}}
+        {%- endif %}
 
   - name: "Solis Eco7 Charge Current"
     unique_id: "Solis Eco7 Charge Current"
@@ -117,6 +129,23 @@ sensor:
       (states('sensor.solis_eco7_time_remaining') | float)
       / (states('sensor.solis_battery_voltage_bms') | float) ) | int / 10
       }}
+
+ 
+  - name: "Solis Flux Discharge Current"
+    unique_id: "Solis Flux Discharge Current"
+    device_class: current
+    state_class: measurement
+    unit_of_measurement: A
+    state: >-
+       {% set value = (
+       ((states('input_number.solis_battery_capacity') | int * 1000) *
+       ((states('sensor.solis_battery_soc') | int) - (states('input_number.flux_target_soc') | int))
+       ) 
+       / 10
+      / 
+       (states('sensor.solis_flux_discharge_hours_remaining') | float)
+       / (states('sensor.solis_battery_voltage_bms') | float) ) | int / 10 %}
+      {{ value if value >= 0 else 0 }}
 
   - name: "Solis Battery Charge Power"
     unique_id: "Solis Battery Charge Power"


### PR DESCRIPTION
I have added discharge support for those on Octopus Flux (or similar) tariffs.

I works pretty much the same as the charging. Fill in the input date times and target SOC, and the automations do the rest. 